### PR TITLE
Pool updates

### DIFF
--- a/src/main/java/com/google/connector/snowflakeToBQ/cache/EasyCache.java
+++ b/src/main/java/com/google/connector/snowflakeToBQ/cache/EasyCache.java
@@ -2,6 +2,8 @@ package com.google.connector.snowflakeToBQ.cache;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import com.google.connector.snowflakeToBQ.repository.ClosableResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,7 +38,13 @@ public class EasyCache<K, V> {
           protected boolean removeEldestEntry(Map.Entry<K, CacheObject<V>> eldest) {
             // Remove the eldest entry if size exceeds maxSize
             log.info("Current cache size:{}", cache.size());
-            return size() > maxSize;
+            if (size() > maxSize) {
+              // Closing the resources if required
+              closeIfNecessary(eldest.getValue().value);
+              return true;
+            }
+            // return false if size is within the limit of maxsize
+            return false;
           }
         };
   }
@@ -69,6 +77,11 @@ public class EasyCache<K, V> {
           key,
           this.ttlMillis,
           cache.size());
+      CacheObject<V> oldCacheObject = cache.get(key);
+      if (oldCacheObject != null) {
+        // Closing the resources if required
+        closeIfNecessary(oldCacheObject.value);
+      }
       cache.remove(key);
       return null;
     }
@@ -76,7 +89,21 @@ public class EasyCache<K, V> {
 
   /** Clears all entries from the cache. */
   public synchronized void clear() {
+    cache.values().forEach(cacheObject -> closeIfNecessary(cacheObject.value));
     cache.clear();
+  }
+
+  /**
+   * This method closes the resources(values) in the cache, if they are closable(implementing
+   * the @{@link ClosableResource}) interface. If the object saved is not closable then this method
+   * will just pass.
+   *
+   * @param value The value of the map, which is the cacheed object.
+   */
+  private void closeIfNecessary(V value) {
+    if (value instanceof ClosableResource) {
+      ((ClosableResource) value).closeResource();
+    }
   }
 
   /**

--- a/src/main/java/com/google/connector/snowflakeToBQ/cache/EasyCache.java
+++ b/src/main/java/com/google/connector/snowflakeToBQ/cache/EasyCache.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.connector.snowflakeToBQ.cache;
 
 import java.util.LinkedHashMap;

--- a/src/main/java/com/google/connector/snowflakeToBQ/config/WebClientConfig.java
+++ b/src/main/java/com/google/connector/snowflakeToBQ/config/WebClientConfig.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.connector.snowflakeToBQ.config;
+
+import io.netty.channel.ChannelOption;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+/**
+ * Configuration class for setting up a custom {@link WebClient} with specific connection pooling
+ * and HTTP client options.
+ *
+ * <p>This configuration class defines a {@link WebClient} bean with custom settings for connection
+ * pooling and timeouts using Reactor Netty.
+ */
+@Configuration
+public class WebClientConfig {
+
+  /*
+   Sets the maximum number of connections that the connection pool can hold
+   at any given time.
+  */
+  @Value("${reactor.netty.max.pool.size}")
+  private int maxPoolSize;
+
+  /*
+   Defines how long a connection can remain idle (unused) in the pool before
+   it's eligible for eviction (closure).
+  */
+  @Value("${reactor.netty.max.idle.time}")
+  private int maxIdleTimeout;
+
+  /*
+   Sets the connection timeout for establishing a connection to the server.
+   If the connection cannot be established within this time, it will time out.
+  */
+  @Value("${reactor.netty.connection.timeout}")
+  private int connectionTimeOutToSnowflake;
+
+  /**
+   * Creates and configures a {@link WebClient} bean with a custom {@link ConnectionProvider} and
+   * {@link HttpClient}.
+   *
+   * <p>The custom {@link ConnectionProvider} sets the maximum number of connections in the pool,
+   * and specifies the maximum idle time for connections. The {@link HttpClient} is configured with
+   * a connection timeout.
+   *
+   * @return a configured {@link WebClient} instance.
+   */
+  @Bean
+  public WebClient webClient() {
+    // Create a custom ConnectionProvider with specific configuration
+    ConnectionProvider provider =
+        ConnectionProvider.builder("snowflake-pool")
+            .maxConnections(maxPoolSize)
+            .maxIdleTime(Duration.ofMillis(maxIdleTimeout))
+                .name("snowflake-pool")// Keep connections alive
+            .build();
+
+    HttpClient httpClient =
+        HttpClient.create(provider)
+            .option(
+                ChannelOption.CONNECT_TIMEOUT_MILLIS,
+                connectionTimeOutToSnowflake);
+
+    return WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient)).build();
+  }
+}

--- a/src/main/java/com/google/connector/snowflakeToBQ/controller/SnowflakesConnectorController.java
+++ b/src/main/java/com/google/connector/snowflakeToBQ/controller/SnowflakesConnectorController.java
@@ -27,6 +27,7 @@ import com.google.connector.snowflakeToBQ.model.datadto.SnowflakeUnloadToGCSData
 import com.google.connector.snowflakeToBQ.model.request.SFDataMigrationRequestDTO;
 import com.google.connector.snowflakeToBQ.model.request.SFExtractAndTranslateDDLRequestDTO;
 import com.google.connector.snowflakeToBQ.model.request.SnowflakeUnloadToGCSRequestDTO;
+import com.google.connector.snowflakeToBQ.repository.ClosableJdbcTemplate;
 import com.google.connector.snowflakeToBQ.service.ApplicationConfigDataService;
 import com.google.connector.snowflakeToBQ.service.ExtractAndTranslateDDLService;
 import com.google.connector.snowflakeToBQ.service.SnowflakeMigrateDataService;
@@ -65,6 +66,8 @@ public class SnowflakesConnectorController {
 
   final OAuthCredentials oauthCredentials;
 
+  final EasyCache<String, ClosableJdbcTemplate> jdbcTemplateEhcache;
+
   public SnowflakesConnectorController(
       EncryptValues encryptValues,
       TokenRefreshService tokenRefreshService,
@@ -72,7 +75,8 @@ public class SnowflakesConnectorController {
       OAuthCredentials oauthCredentials,
       ExtractAndTranslateDDLService extractDDLService,
       SnowflakeUnloadToGCSAsyncService snowflakeUnloadToGCSAsyncService,
-      ApplicationConfigDataService applicationConfigDataService) {
+      ApplicationConfigDataService applicationConfigDataService,
+      EasyCache<String, ClosableJdbcTemplate> jdbcTemplateEhcache) {
     this.encryptValues = encryptValues;
     this.tokenRefreshService = tokenRefreshService;
     this.snowflakeMigrateDataService = snowflakeMigrateDataService;
@@ -80,6 +84,7 @@ public class SnowflakesConnectorController {
     this.extractDDLService = extractDDLService;
     this.snowflakeUnloadToGCSAsyncService = snowflakeUnloadToGCSAsyncService;
     this.applicationConfigDataService = applicationConfigDataService;
+    this.jdbcTemplateEhcache = jdbcTemplateEhcache;
   }
 
   /**
@@ -257,6 +262,7 @@ public class SnowflakesConnectorController {
     // execution. Using the below line, when user set the new value it will be refreshed, so the map
     // will  contain  the new access token value.
     tokenRefreshService.refreshToken();
+    jdbcTemplateEhcache.clear();
     String message =
         String.format(
             "OAUTH credentials have been successfully saved at %s,Request Log Id:%s",

--- a/src/main/java/com/google/connector/snowflakeToBQ/controller/SnowflakesConnectorController.java
+++ b/src/main/java/com/google/connector/snowflakeToBQ/controller/SnowflakesConnectorController.java
@@ -65,8 +65,6 @@ public class SnowflakesConnectorController {
 
   final OAuthCredentials oauthCredentials;
 
-  final EasyCache<String, JdbcTemplate> jdbcTemplateEhcache;
-
   public SnowflakesConnectorController(
       EncryptValues encryptValues,
       TokenRefreshService tokenRefreshService,
@@ -74,8 +72,7 @@ public class SnowflakesConnectorController {
       OAuthCredentials oauthCredentials,
       ExtractAndTranslateDDLService extractDDLService,
       SnowflakeUnloadToGCSAsyncService snowflakeUnloadToGCSAsyncService,
-      ApplicationConfigDataService applicationConfigDataService,
-      EasyCache<String, JdbcTemplate> jdbcTemplateEhcache) {
+      ApplicationConfigDataService applicationConfigDataService) {
     this.encryptValues = encryptValues;
     this.tokenRefreshService = tokenRefreshService;
     this.snowflakeMigrateDataService = snowflakeMigrateDataService;
@@ -83,7 +80,6 @@ public class SnowflakesConnectorController {
     this.extractDDLService = extractDDLService;
     this.snowflakeUnloadToGCSAsyncService = snowflakeUnloadToGCSAsyncService;
     this.applicationConfigDataService = applicationConfigDataService;
-    this.jdbcTemplateEhcache = jdbcTemplateEhcache;
   }
 
   /**
@@ -261,7 +257,6 @@ public class SnowflakesConnectorController {
     // execution. Using the below line, when user set the new value it will be refreshed, so the map
     // will  contain  the new access token value.
     tokenRefreshService.refreshToken();
-    jdbcTemplateEhcache.clear();
     String message =
         String.format(
             "OAUTH credentials have been successfully saved at %s,Request Log Id:%s",

--- a/src/main/java/com/google/connector/snowflakeToBQ/repository/ClosableJdbcTemplate.java
+++ b/src/main/java/com/google/connector/snowflakeToBQ/repository/ClosableJdbcTemplate.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.connector.snowflakeToBQ.repository;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * A subclass of {@link JdbcTemplate} that implements the {@link ClosableResource} interface.
+ *
+ * <p>This class provides a custom implementation of {@link JdbcTemplate} with the ability to close
+ * the associated {@link HikariDataSource} when the resource is no longer needed. This is
+ * particularly useful when the {@link ClosableJdbcTemplate} is used in conjunction with the {@link
+ * com.google.connector.snowflakeToBQ.cache.EasyCache} class, allowing the JDBC connection pool to
+ * be properly cleaned up when entries are removed from the cache or when the cache is cleared.
+ *
+ * <p>Example usage:
+ *
+ * <pre>
+ * ClosableJdbcTemplate jdbcTemplate = new ClosableJdbcTemplate(dataSource);
+ * cache.put("myKey", jdbcTemplate);
+ * </pre>
+ *
+ * <p>When the entry is removed from the cache, the associated {@link HikariDataSource} will be
+ * closed automatically.
+ */
+public class ClosableJdbcTemplate extends JdbcTemplate implements ClosableResource {
+
+  private final HikariDataSource dataSource;
+
+  /**
+   * Constructs a new {@link ClosableJdbcTemplate} with the specified {@link HikariDataSource}.
+   *
+   * @param dataSource the {@link HikariDataSource} to be used by this {@link JdbcTemplate}
+   *     instance. The dataSource will be closed when {@link #closeResource()} is called.
+   */
+  public ClosableJdbcTemplate(HikariDataSource dataSource) {
+    super(dataSource);
+    this.dataSource = dataSource;
+  }
+
+  /**
+   * Closes the associated {@link HikariDataSource}, releasing any database connections and cleaning
+   * up resources.
+   *
+   * <p>This method is automatically called when the {@link ClosableJdbcTemplate} is removed from
+   * the cache, ensuring that database connections are properly closed.
+   */
+  @Override
+  public synchronized void closeResource() {
+    dataSource.close();
+  }
+}

--- a/src/main/java/com/google/connector/snowflakeToBQ/repository/ClosableResource.java
+++ b/src/main/java/com/google/connector/snowflakeToBQ/repository/ClosableResource.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.connector.snowflakeToBQ.repository;
+
+/**
+ * An interface that defines a resource with a closeable operation.
+ *
+ * <p>Implementing classes should provide the logic to release or clean up
+ * any resources that need to be managed explicitly, such as database connections,
+ * network connections, file handles, etc. This interface allows such classes
+ * to integrate with resource management in the {@link com.google.connector.snowflakeToBQ.cache.EasyCache} class.</p>
+ *
+ * <p>This interface is particularly useful for resources that are stored in a cache
+ * and need to be cleaned up when they are removed from the cache or when the cache is cleared.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * public class MyResource implements ClosableResource {
+ *     // Resource-specific fields and methods
+ *
+ *     {@literal @}Override
+ *     public void closeResource() {
+ *         // Logic to clean up or release resources
+ *     }
+ * }
+ * </pre>
+ */
+public interface ClosableResource {
+    /**
+     * Closes the resource, releasing any underlying resources such as connections,
+     * streams, or handles. Implementing classes should ensure that this method
+     * can be called multiple times safely.
+     */
+    void closeResource();
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,5 +69,5 @@ custom.thread.executor.max.pool.size=10
 #logging.level.org.springframework=DEBUG
 #Maximum number of element which would remain in a cache
 cache.maxSize:5
-#Below value is 24 hours in millisecond
+#Below value is 30 min in millisecond
 cache.ttlMillis=1800000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,7 +67,15 @@ migration.workflow.duration=300000
 custom.thread.executor.max.pool.size=10
 # Enable below property to print DEBUG level logs. This can also be supplied during application startup.
 #logging.level.org.springframework=DEBUG
+#logging.level.reactor.netty=DEBUG
+#logging.level.io.netty.handler.logging.LoggingHandler=DEBUG
 #Maximum number of element which would remain in a cache
 cache.maxSize:5
 #Below value is 30 min in millisecond
 cache.ttlMillis=1800000
+# Sets the maximum number of connections that the reactor connection pool can hold at any given time.
+reactor.netty.max.pool.size=20
+# Time to define how long(ms) a connection can remain idle (unused) in the reactor pool before it's eligible for eviction (closure).
+reactor.netty.max.idle.time=300000
+# Connection timeout(ms) for establishing a connection to the snowflake server.If the connection cannot be established within this time, it will time out.
+reactor.netty.connection.timeout=10000

--- a/src/test/java/com/google/connector/snowflakeToBQ/repository/ClosableJdbcTemplateTest.java
+++ b/src/test/java/com/google/connector/snowflakeToBQ/repository/ClosableJdbcTemplateTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.connector.snowflakeToBQ.repository;
+
+import static org.mockito.Mockito.*;
+
+import com.google.connector.snowflakeToBQ.base.AbstractTestBase;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClosableJdbcTemplateTest extends AbstractTestBase {
+
+  private HikariDataSource mockDataSource;
+  private ClosableJdbcTemplate closableJdbcTemplate;
+
+  @Before
+  public void setUp() {
+    // Create a mock HikariDataSource
+    mockDataSource = mock(HikariDataSource.class);
+    // Create an instance of ClosableJdbcTemplate with the mock data source
+    closableJdbcTemplate = new ClosableJdbcTemplate(mockDataSource);
+  }
+
+  @Test
+  public void testCloseResource() {
+    // Call the closeResource method
+    closableJdbcTemplate.closeResource();
+
+    // Verify that the close method on the mock data source was called
+    verify(mockDataSource).close();
+  }
+
+  @Test
+  public void testDataSourceIsNotClosedMultipleTimes() {
+    // Call the closeResource method twice
+    closableJdbcTemplate.closeResource();
+
+    // Verify that the close method on the mock data source was called only once
+    verify(mockDataSource, times(1)).close();
+  }
+}

--- a/src/test/java/com/google/connector/snowflakeToBQ/service/RestAPIExecutionServiceTest.java
+++ b/src/test/java/com/google/connector/snowflakeToBQ/service/RestAPIExecutionServiceTest.java
@@ -18,6 +18,7 @@ package com.google.connector.snowflakeToBQ.service;
 
 import com.google.connector.snowflakeToBQ.base.AbstractTestBase;
 import com.google.connector.snowflakeToBQ.config.OAuthCredentials;
+import com.google.connector.snowflakeToBQ.config.WebClientConfig;
 import com.google.connector.snowflakeToBQ.exception.SnowflakeConnectorException;
 import com.google.connector.snowflakeToBQ.model.EncryptedData;
 import com.google.connector.snowflakeToBQ.util.CommonMethods;
@@ -41,7 +42,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 public class RestAPIExecutionServiceTest extends AbstractTestBase {
   @Autowired private RestAPIExecutionService restAPIExecutionService;
 
-  @MockBean WebClient webClientMock;
+  @MockBean
+  WebClientConfig webClientConfigMock;
   @MockBean OAuthCredentials oauthCredentials;
   @MockBean EncryptValues encryptDecryptValues;
   @MockBean TokenRefreshService tokenRefreshService;
@@ -76,6 +78,8 @@ public class RestAPIExecutionServiceTest extends AbstractTestBase {
     // Define the expected argument values for the method chain
     String expectedUrl = "https://testing.snowflakecomputing.com/api/v2/statements/";
     // Stub the behavior of the WebClient instance and its method chain
+    WebClient webClientMock=Mockito.mock(WebClient.class);
+    Mockito.when(webClientConfigMock.webClient()).thenReturn(webClientMock);
     Mockito.when(webClientMock.get()).thenReturn(requestHeadersUriSpecMock);
     Mockito.when(requestHeadersUriSpecMock.uri(anyString())).thenReturn(requestHeadersSpecMock);
     Mockito.when(requestHeadersSpecMock.header(Mockito.eq("Authorization"), anyString()))
@@ -126,6 +130,8 @@ public class RestAPIExecutionServiceTest extends AbstractTestBase {
     // Define the expected argument values for the method chain
     String expectedUrl = "https://testing.snowflakecomputing.com/api/v2/statements/";
     // Stub the behavior of the WebClient instance and its method chain
+    WebClient webClientMock=Mockito.mock(WebClient.class);
+    Mockito.when(webClientConfigMock.webClient()).thenReturn(webClientMock);
     Mockito.when(webClientMock.get()).thenReturn(requestHeadersUriSpecMock);
     Mockito.when(requestHeadersUriSpecMock.uri(anyString())).thenReturn(requestHeadersSpecMock);
     Mockito.when(requestHeadersSpecMock.header(Mockito.eq("Authorization"), anyString()))
@@ -182,6 +188,8 @@ public class RestAPIExecutionServiceTest extends AbstractTestBase {
     String expectedUrl = "https://testing.snowflakecomputing.com/api/v2/statements/";
 
     // Stub the behavior of the WebClient instance and its method chain
+    WebClient webClientMock=Mockito.mock(WebClient.class);
+    Mockito.when(webClientConfigMock.webClient()).thenReturn(webClientMock);
     Mockito.when(webClientMock.get()).thenReturn(requestHeadersUriSpecMock);
     Mockito.when(requestHeadersUriSpecMock.uri(anyString())).thenReturn(requestHeadersSpecMock);
     Mockito.when(requestHeadersSpecMock.header(Mockito.eq("Authorization"), anyString()))
@@ -251,7 +259,10 @@ public class RestAPIExecutionServiceTest extends AbstractTestBase {
     // Define the expected argument values for the method chain
     String expectedUrl = "https://testing.snowflakecomputing.com/api/v2/statements/";
     // Stub the behavior of the WebClient instance and its method chain
+    WebClient webClientMock=Mockito.mock(WebClient.class);
+    Mockito.when(webClientConfigMock.webClient()).thenReturn(webClientMock);
     Mockito.when(webClientMock.get()).thenReturn(requestHeadersUriSpecMock);
+
     Mockito.when(requestHeadersUriSpecMock.uri(anyString())).thenReturn(requestHeadersSpecMock);
     Mockito.when(requestHeadersSpecMock.header(Mockito.eq("Authorization"), anyString()))
         .thenReturn(requestHeadersSpecMock);
@@ -289,7 +300,10 @@ public class RestAPIExecutionServiceTest extends AbstractTestBase {
     // Define the expected argument values for the method chain
     String expectedUrl = "https://testing.snowflakecomputing.com/api/v2/statements/";
     // Stub the behavior of the WebClient instance and its method chain
+    WebClient webClientMock=Mockito.mock(WebClient.class);
+    Mockito.when(webClientConfigMock.webClient()).thenReturn(webClientMock);
     Mockito.when(webClientMock.get()).thenReturn(requestHeadersUriSpecMock);
+
     Mockito.when(requestHeadersUriSpecMock.uri(anyString())).thenReturn(requestHeadersSpecMock);
     Mockito.when(requestHeadersSpecMock.header(Mockito.eq("Authorization"), anyString()))
         .thenReturn(requestHeadersSpecMock);

--- a/src/test/resources/test-application.properties
+++ b/src/test/resources/test-application.properties
@@ -43,3 +43,9 @@ custom.thread.executor.max.pool.size=10
 gcs.storage.integration=MIGRATION_INTEGRATION
 cache.maxSize:3
 cache.ttlMillis=1000
+# Sets the maximum number of connections that the reactor connection pool can hold at any given time.
+reactor.netty.max.pool.size=20
+# Time to define how long(ms) a connection can remain idle (unused) in the reactor pool before it's eligible for eviction (closure).
+reactor.netty.max.idle.time=300000
+# Connection timeout(ms) for establishing a connection to the snowflake server.If the connection cannot be established within this time, it will time out.
+reactor.netty.connection.timeout=10000


### PR DESCRIPTION
This PR contains changes related to below functionality.
1: Changing the JDBCTemplate to closableJDbcTemplate so that the JDBC pool get closed when expired or removed from the EasyCache.
2: Better handing of reactor and netty pool and connection for WebClient class. 
3: Updating the test cases based on the changes